### PR TITLE
fix_ieee_754_nan

### DIFF
--- a/autonomous_steering_logic.py
+++ b/autonomous_steering_logic.py
@@ -12,9 +12,7 @@ class AutonomousSteeringLogic:
     self.binary_converter = BinaryConverter()
     self.genome_helper = GenomeHelper()
 
-  def get_steering_dict(self, genome, sensors_input):
-    engine_signal, wheels_signal = self.genome_helper.engine_wheels_signal(genome)
-
+  def get_steering_dict(self, engine_signal, wheels_signal, sensors_input):
     engine_signal = self.linear_polynomial(engine_signal, sensors_input)
     wheels_signal = self.linear_polynomial(wheels_signal, sensors_input)
 

--- a/binary_converter.py
+++ b/binary_converter.py
@@ -1,8 +1,11 @@
 import struct
 import numpy as np
+import math
 
 class BinaryConverter:
   BITS_COUNT = 16
+  EXPONENT_COUNT = 5
+  SIGNIFICAND_COUNT = 10
   BIAS_UNITS = 1
 
   def float_to_bin(self, num):
@@ -12,7 +15,13 @@ class BinaryConverter:
   def bin_to_float(self, binary):
     string_binary = "".join(str(x) for x in binary)
     y = struct.pack("H", int(string_binary, 2))
-    return np.frombuffer(y, dtype =np.float16)[0]
+    r = np.frombuffer(y, dtype =np.float16)[0]
+    if math.isnan(r):
+      print(r)
+    if r == 0:
+      print(r)
+      print(binary)
+    return r
 
   def string_to_int_array(self, binary_string):
     return [int(d) for d in binary_string]

--- a/cars/autonomous_controlled_car.py
+++ b/cars/autonomous_controlled_car.py
@@ -1,15 +1,21 @@
 from cars.controlled_car import ControlledCar
 from genome_helper import GenomeHelper
 from autonomous_steering_logic import AutonomousSteeringLogic
+import math
 
 class AutonomousControlledCar(ControlledCar):
   def __init__(self, pos_x, pos_y, screen, game):
     ControlledCar.__init__(self, pos_x, pos_y, screen, game)
     self.autonomous_steering_logic = AutonomousSteeringLogic()
+    self.genome_helper = GenomeHelper()
     self.genome = []
 
   def set_genome(self, genome):
     self.genome = genome
+    coefficients = self.genome_helper.genome_to_decimals(self.genome)
+    engine_signal, wheels_signal = self.genome_helper.engine_wheels_signal(coefficients)
+    self.engine_signal = engine_signal
+    self.wheels_signal = wheels_signal
 
   def reset(self, pos_x, pos_y):
     self.init_moving(pos_x, pos_y)
@@ -17,5 +23,5 @@ class AutonomousControlledCar(ControlledCar):
 
   def get_steering_dict(self):
     sensors_input = [s['sensor'].actual_length_in_meter() for s in self.sensors]
-    return self.autonomous_steering_logic.get_steering_dict(self.genome, sensors_input)
+    return self.autonomous_steering_logic.get_steering_dict(self.engine_signal, self.wheels_signal, sensors_input)
     # return ControlledCar.get_steering_dict(self)

--- a/genetic_program.py
+++ b/genetic_program.py
@@ -3,7 +3,7 @@ from genetic_helper import GeneticHelper
 from cars.autonomous_controlled_car import AutonomousControlledCar
 import pygame
 
-GENERATION_SIZE = 10
+GENERATION_SIZE = 16
 MUTATION_PROBABILITY = 0.04
 
 class GeneticProgram(BaseProgram):
@@ -66,12 +66,13 @@ class GeneticProgram(BaseProgram):
       new_population = []
       for i in range(0, len(selected_population)-1, 2):
         child1, child2 = self.genetic_helper.crossover(selected_population[i].genome, selected_population[i+1].genome)
-        self.genetic_helper.mutate_genome(child1, MUTATION_PROBABILITY)
-        self.genetic_helper.mutate_genome(child2, MUTATION_PROBABILITY)
+        self.genetic_helper.mutate_ieee_754_genome(child1, MUTATION_PROBABILITY)
+        self.genetic_helper.mutate_ieee_754_genome(child2, MUTATION_PROBABILITY)
         new_population.append(child1)
         new_population.append(child2)
         # if len(new_population) < GENERATION_SIZE:
           # new_population.append(child2)
       self.set_cars_genomes(new_population)
       [car.reset(700, 430) for car in self.steerable_cars]
+    print(best_fitness_car)
     pygame.quit()

--- a/genome_helper.py
+++ b/genome_helper.py
@@ -4,9 +4,12 @@ import numpy as np
 
 class GenomeHelper:
   GENES_PER_NUMBER = BinaryConverter.BITS_COUNT
+  EXPONENT_COUNT = BinaryConverter.EXPONENT_COUNT
+  SIGNIFICAND_COUNT = BinaryConverter.SIGNIFICAND_COUNT
   BIAS_UNITS = BinaryConverter.BIAS_UNITS
 
   NUMBERS_PEER_STEER = ControlledCar.CAR_SENSORS_NUM + BIAS_UNITS
+  NUMBERS_PEER_GENOME = NUMBERS_PEER_STEER * 2
   PEER_STEER_GENES = NUMBERS_PEER_STEER * GENES_PER_NUMBER;
   # Genes for engine and wheels
   GENOME_LENGTH = PEER_STEER_GENES * 2
@@ -27,11 +30,50 @@ class GenomeHelper:
 
     return decimals
 
-  def engine_wheels_signal(self, binary_genome):
+  def engine_wheels_signal_from_binary(self, binary_genome):
     genome_numbers = self.genome_to_decimals(binary_genome)
+    return self.engine_wheels_signal(genome_numbers)
+
+  def engine_wheels_signal(self, genome_numbers):
     engine_signal = genome_numbers[0 : self.NUMBERS_PEER_STEER]
     wheels_signal = genome_numbers[self.NUMBERS_PEER_STEER : self.NUMBERS_PEER_STEER * 2]
     return engine_signal, wheels_signal
 
-  def init_randomly(self, genome_size=GENOME_LENGTH):
-    return np.random.randint(2, size=genome_size).tolist()
+  def init_number_randomly(self, exponent_count=EXPONENT_COUNT, significand_count=SIGNIFICAND_COUNT):
+    sign = np.random.randint(2, size=1).tolist()
+    exponent = np.random.randint(2, size=exponent_count).tolist()
+    # If all numbers in exponent are set to 1, final number will be converted to inifinity
+    # Its one of the rule of IEEE 754
+    while all(num == 1 for num in exponent):
+      exponent = np.random.randint(2, size=exponent_count).tolist()
+    significand = np.random.randint(2, size=significand_count).tolist()
+    return sign + exponent + significand
+
+  def init_randomly(self, numbers_per_genome=NUMBERS_PEER_GENOME):
+    binary_genome = []
+    for _ in range(numbers_per_genome):
+      binary_genome.extend(self.init_number_randomly())
+    return binary_genome
+
+  # If number's exponent part contains only 1s, it means the number is Nan or Infinity
+  def check_if_number_forbidden(self, binary_number):
+    if len(binary_number) != self.GENES_PER_NUMBER: 
+      raise Exception("Binary number has wrong length")
+
+    exponent = binary_number[1:self.EXPONENT_COUNT]
+    significand = binary_number[self.GENES_PER_NUMBER-self.SIGNIFICAND_COUNT:]
+    if all(num == 1 for num in exponent):
+      return True
+
+    return False
+
+  def check_if_any_number_forbidden(self, binary_genome):
+    for idx in range(0, len(binary_genome), self.GENES_PER_NUMBER):
+      binary_number = binary_genome[idx:idx+self.GENES_PER_NUMBER]
+      if self.check_if_number_forbidden(binary_number):
+        return True
+
+    return False
+
+
+

--- a/tests/test_binary_converter.py
+++ b/tests/test_binary_converter.py
@@ -27,6 +27,12 @@ class TestBinaryConverter(unittest.TestCase):
     result = self.logic.bin_to_float([1,1,0,0,1,1,0,1,0,1,0,0,0,1,0,1])
     self.assertEqual(np.float16(-21.085), result)
 
+    result = self.logic.bin_to_float([1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0])
+    self.assertEqual('-inf', str(result))
+
+    result = self.logic.bin_to_float([1,1,1,1,1,1,0,0,0,0,1,0,0,0,0,0])
+    self.assertEqual('nan', str(result))
+
   def test_string_to_int_array(self):
     result = self.logic.string_to_int_array('00111011001')
     self.assertEqual([0,0,1,1,1,0,1,1,0,0,1], result)

--- a/tests/test_genetic_helper.py
+++ b/tests/test_genetic_helper.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 from genetic_helper import GeneticHelper
+from genome_helper import GenomeHelper
 
 class TestGeneticHelper(unittest.TestCase):
   def setUp(self):
@@ -10,6 +11,11 @@ class TestGeneticHelper(unittest.TestCase):
     with patch('random.randint', return_value=3) as mock_random:
       result = self.genetic_helper.crossover([0, 1, 0, 1, 1, 0, 1],[1, 1, 0, 1, 0, 1, 0])
       self.assertEqual(([0, 1, 0, 1, 0, 1, 0], [1, 1, 0, 1, 1, 0, 1] ), result)
+
+  def test_crossover_ieee_754(self):
+    with patch('random.randint', return_value=4) as mock_random:
+      result = self.genetic_helper.crossover_ieee_754([1,0,1,1,0,1,0,0,0,0,0,0,0,0,1,1],[0,1,1,0,1,0,0,1,1,0,1,0,1,0,0,0])
+      self.assertEqual(([1,0,1,1,1,0,0,1,1,0,1,0,1,0,0,0], [0,1,1,0,0,1,0,0,0,0,0,0,0,0,1,1] ), result)
 
   def test_crossover_with_incompatibile_arrays(self):
     with self.assertRaisesRegex(Exception, "Lengths of passed arrays are not the same"):
@@ -21,10 +27,16 @@ class TestGeneticHelper(unittest.TestCase):
 
     self.assertEqual([1,1,1,0,0,1,0,1,1,0,1,1], binary_genome)
 
+  def test_mutate_ieee_754_genome_with_high_probability(self):
+    binary_genome = [1,0,1,1,0,1,0,0,0,0,0,0,0,0,1,1, 1,1,1,1,1,1,1,0,0,1,0,0,0,0,1,1]
+    self.genetic_helper.mutate_ieee_754_genome(binary_genome, probability=1.0)
+
+    self.assertEqual([0,1,0,0,1,0,1,1,1,1,1,1,1,1,0,0,  0,0,0,0,0,0,0,1,1,0,1,1,1,1,0,0], binary_genome)
+
   def test_create_random_generation(self):
-    result = self.genetic_helper.create_random_generation(5, 6)
+    result = self.genetic_helper.create_random_generation(5, 2)
     self.assertEqual(5, len(result))
-    self.assertEqual(6, len(result[0]))
+    self.assertEqual(2 * GenomeHelper.GENES_PER_NUMBER , len(result[0]))
 
 
 if __name__ == '__main__':

--- a/tests/test_genome_helper.py
+++ b/tests/test_genome_helper.py
@@ -32,7 +32,7 @@ class TestGenome(unittest.TestCase):
     self.assertEqual(np.float16(-122.5), result[1])
     self.assertEqual(np.float16(-9.12), result[2])
 
-  def test_engine_wheels_signal(self):
+  def test_engine_wheels_signal_from_binary(self):
     binary = []
     for idx in range(GenomeHelper.NUMBERS_PEER_STEER):
       binary.extend([0,1,0,0,1,1,1,0,0,0,0,1,0,0,1,1]) # 24.3
@@ -41,7 +41,7 @@ class TestGenome(unittest.TestCase):
 
     self.assertEqual(352, len(binary))
 
-    engine_signal, wheels_signal = self.genome_helper.engine_wheels_signal(binary)
+    engine_signal, wheels_signal = self.genome_helper.engine_wheels_signal_from_binary(binary)
     self.assertEqual(11, len(engine_signal))
     self.assertEqual(11, len(wheels_signal))
 
@@ -50,10 +50,45 @@ class TestGenome(unittest.TestCase):
 
   def test_init_randomly(self):
     binary_genome = self.genome_helper.init_randomly()
-    
+
     self.assertEqual(GenomeHelper.GENOME_LENGTH, len(binary_genome))
     self.assertTrue(binary_genome[0] == 0 or 1 )
     self.assertTrue(binary_genome[1] == 0 or 1 )
+
+  def test_init_number_randomly(self):
+    binary_genome = self.genome_helper.init_number_randomly(5, 6)
+    # 1 sign bit, 5 exponent bits, 6 significand bits
+    self.assertEqual(12, len(binary_genome))
+    self.assertTrue(binary_genome[0] == 0 or 1 )
+    self.assertTrue(binary_genome[1] == 0 or 1 )
+
+  def test_check_if_any_number_forbidden_with_error(self):
+    with self.assertRaisesRegex(Exception, "Binary number has wrong length"):
+      self.genome_helper.check_if_any_number_forbidden([0,1,1,0,0,0,0,1,0,0,1,1])
+
+  def test_check_if_any_number_forbidden(self):
+    is_forbidden = self.genome_helper.check_if_any_number_forbidden([1,0,1,1,0,1,0,0,0,0,0,0,0,0,0,0,  1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0])
+    self.assertEqual(True, is_forbidden)    
+
+    is_forbidden = self.genome_helper.check_if_any_number_forbidden([0,1,1,1,1,1,0,0,0,0,1,0,0,1,0,1,  0,1,0,0,1,0,0,0,0,0,0,1,0,1,0,1])
+    self.assertEqual(True, is_forbidden)
+
+    is_forbidden = self.genome_helper.check_if_any_number_forbidden([0,1,1,0,1,1,0,0,0,0,0,1,0,0,1,1, 1,1,0,0,0,0,0,0,0,0,0,1,1,1,0,1])
+    self.assertEqual(False, is_forbidden)
+
+  def test_check_if_number_forbidden(self):
+    with self.assertRaisesRegex(Exception, "Binary number has wrong length"):
+      self.genome_helper.check_if_any_number_forbidden([0,1,1,0,0,0,1,1])
+
+    is_forbidden = self.genome_helper.check_if_number_forbidden([1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0])
+    self.assertEqual(True, is_forbidden)    
+
+    is_forbidden = self.genome_helper.check_if_number_forbidden([1,1,1,1,1,1,0,0,0,1,0,0,1,0,1,1])
+    self.assertEqual(True, is_forbidden)
+
+    is_forbidden = self.genome_helper.check_if_number_forbidden([1,1,0,0,0,0,0,0,0,0,0,1,1,1,0,1])
+    self.assertEqual(False, is_forbidden)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There were cases when mutation or crossover of a genome caused some numbers to have the exponent's part all set to 1s.
Those numbers were converted to nan or infinity later on
https://en.wikipedia.org/wiki/IEEE_754-1985#Representation_of_non-numbers